### PR TITLE
Improved get role arn method.

### DIFF
--- a/lambkin/aws.py
+++ b/lambkin/aws.py
@@ -27,7 +27,8 @@ def get_role_arn(role):
     get_role_arn('lambda-basic-execution')
     "arn:aws:iam::329487123:role/lambda-basic-execution"
     """
-    return "%s:role/%s" % (get_iam_arn_prefix(), role)
+    role = boto3.resource('iam').Role(role)
+    return role.arn
 
 
 def get_event_rule_arn(rule):


### PR DESCRIPTION
In case the default role(lambda-basic-execution), or any role that gets passed in as parameter does not exist it would raise:
botocore.exceptions.ClientError: An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name lambda-basic-execution cannot be found.
instead of
botocore.exceptions.ClientError: An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: The role defined for the function cannot be assumed by Lambda.