### PR TITLE
Redact the example AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Prerequisites
 * A valid `~/.aws/credentials` file. eg.
 ```
 [default]
-aws_access_key_id = AKIAUAVOHGHOOWEEYIED
-aws_secret_access_key = 90kX2Y2bykTH9CpQFHCzN92tukYf26
+aws_access_key_id = your_access_key_id
+aws_secret_access_key = your_secret_access_key
 ```
 ... or the equivalent environment variables (`AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY`).


### PR DESCRIPTION
This removes ambiguity surrounding the origin of these example credentials (which I presume are innocuous and invalid), and replaces the keys with text that matches the upstream documentation [1].

[1] https://docs.aws.amazon.com/amazonswf/latest/awsrbflowguide/set-up-creds.html